### PR TITLE
chore(fibonacci): update to latest example from https://github.com/lita-xyz/fibonacci/pull/7

### DIFF
--- a/fibonacci/README.md
+++ b/fibonacci/README.md
@@ -7,7 +7,7 @@ This is a simple program that calculates the n-th fibonacci number and proves th
 Build the project, from the root directory of this repo:
 
 ```
-cargo +valida build
+cargo +valida build --release
 ```
 
 To run the program, in the Valida shell, from the root directory of this repo:

--- a/fibonacci/src/main.rs
+++ b/fibonacci/src/main.rs
@@ -3,16 +3,29 @@
 entrypoint::entrypoint!(main);
 
 pub fn main() {
-    // NOTE: values of n larger than 46 will overflow the u32 type.
-    let n = unsafe { entrypoint::io::getchar() as u8 };
+    entrypoint::io::println("Please enter a number from 0 to 46:");
+    // Read a line from stdin and parse it as an u8.
+    let n = loop {
+        match entrypoint::io::read_line::<u8>() {
+            Ok(num) => break num,
+            Err(e) => {
+                entrypoint::io::println(&format!("Error reading input: {}. Please try again:", e));
+            }
+        }
+    };
+    // n that is larger than 46 will overflow the u32 type.
+    if n > 46 {
+        entrypoint::io::println("Error: n is too large. Please enter a number no more than 46.");
+        return;
+    }
     let mut a: u32 = 0;
     let mut b: u32 = 1;
     let mut sum: u32;
     for _ in 1..n {
-            sum = a + b;
-            a = b;
-            b = sum;
-        }
+        sum = a + b;
+        a = b;
+        b = sum;
+    }
 
     entrypoint::io::println(&n.to_string());
     entrypoint::io::println("-th fibonacci number is:");


### PR DESCRIPTION
- uses `read_line`
- fix build instruction to use `build --release` as valida run looks into the release folder.